### PR TITLE
Fixes #14 and #15: Imports SQS and checks twilio error code

### DIFF
--- a/sms.js
+++ b/sms.js
@@ -16,8 +16,6 @@ exports.handler = async function(event) {
     smsTemplate
   } = await getSmsConfig()
   const sqs = new SQS({
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION
   })
   const client = twilio(accountSid, authToken)

--- a/sms.js
+++ b/sms.js
@@ -39,6 +39,7 @@ exports.handler = async function(event) {
       await insertMetric(db, 'SMS_SENT', 'lambda', '')
     } catch (error) {
       if (error.code === 21211) {
+        // Twilio error code docs: https://www.twilio.com/docs/api/errors/21211
         console.log(
           `twilio rejected mobile as invalid - sms not sent for verification code ${code} and will not be retried`
         )

--- a/sms.js
+++ b/sms.js
@@ -1,4 +1,5 @@
 const twilio = require('twilio')
+const { SQS } = require('aws-sdk')
 const { getDatabase, getSmsConfig, insertMetric, runIfDev } = require('./utils')
 
 function parseTemplate(template, values) {
@@ -14,6 +15,11 @@ exports.handler = async function(event) {
     queueUrl,
     smsTemplate
   } = await getSmsConfig()
+  const sqs = new SQS({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    region: process.env.AWS_REGION
+  })
   const client = twilio(accountSid, authToken)
   const db = await getDatabase()
 
@@ -32,19 +38,25 @@ exports.handler = async function(event) {
 
       await insertMetric(db, 'SMS_SENT', 'lambda', '')
     } catch (error) {
-      const delay = 30
+      if (error.code === 21211) {
+        console.log(
+          `twilio rejected mobile as invalid - sms not sent for verification code ${code} and will not be retried`
+        )
+      } else {
+        const delay = 30
 
-      console.error(error)
-      console.log(`retrying request in ${delay} seconds`)
+        console.error(error)
+        console.log(`retrying request in ${delay} seconds`)
 
-      const message = {
-        QueueUrl: queueUrl,
-        MessageBody: JSON.stringify({ code, mobile, onsetDate, testDate }),
-        DelaySeconds: delay
+        const message = {
+          QueueUrl: queueUrl,
+          MessageBody: JSON.stringify({ code, mobile, onsetDate, testDate }),
+          DelaySeconds: delay
+        }
+
+        // eslint-disable-next-line no-undef
+        await sqs.sendMessage(message).promise()
       }
-
-      // eslint-disable-next-line no-undef
-      await sqs.sendMessage(message).promise()
     }
   }
 


### PR DESCRIPTION
For #14: I've added the proper SQS import and setup code
For #15: I've added a check against the error code. If the code is 21211 (twilio invalid phone code) then we will log out at INFO level "twilio rejected mobile as invalid - sms not sent for verification code 12345 and will not be retried" (with the appropriate verification code.

@segfault for #14 I've not been able to confirm completely that the message is added back to the queue. It appears that the lambda doesn't have the appropriate permissions to post to the queue (or the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` parameters are not what I'm expecting them to be). I'm still seeing error 

```
{
    "errorType": "InvalidClientTokenId",
    "errorMessage": "The security token included in the request is invalid.",
    "code": "InvalidClientTokenId",
    "message": "The security token included in the request is invalid.",
    "time": "2020-08-30T01:00:42.955Z",
    "requestId": "f92d1879-9fd1-575c-aba7-4fbd63abd940",
    "statusCode": 403,
    "retryable": false,
    "retryDelay": 61.191860126264494,
    "stack": [
        "InvalidClientTokenId: The security token included in the request is invalid.",
        "    at Request.extractError (/var/task/node_modules/aws-sdk/lib/protocol/query.js:50:29)",
        "    at Request.callListeners (/var/task/node_modules/aws-sdk/lib/sequential_executor.js:106:20)",
        "    at Request.emit (/var/task/node_modules/aws-sdk/lib/sequential_executor.js:78:10)",
        "    at Request.emit (/var/task/node_modules/aws-sdk/lib/request.js:683:14)",
        "    at Request.transition (/var/task/node_modules/aws-sdk/lib/request.js:22:10)",
        "    at AcceptorStateMachine.runTo (/var/task/node_modules/aws-sdk/lib/state_machine.js:14:12)",
        "    at /var/task/node_modules/aws-sdk/lib/state_machine.js:26:10",
        "    at Request.<anonymous> (/var/task/node_modules/aws-sdk/lib/request.js:38:9)",
        "    at Request.<anonymous> (/var/task/node_modules/aws-sdk/lib/request.js:685:12)",
        "    at Request.callListeners (/var/task/node_modules/aws-sdk/lib/sequential_executor.js:116:18)"
    ]
}
```