### PR TITLE
Fix ordering of statewide moving average values

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -133,13 +133,11 @@ exports.getAggregateByDate = byDate => {
   exports.getMovingAverage(aggregateByDayAsArray)
 
   // Remove unwanted values after using test_date in moving average calc sorter
-  const aggregateByDayPruned = aggregateByDate.map(stat => {
-    const prunedStat = { ...stat }
-    delete prunedStat.county
-    delete prunedStat.test_date
-    return prunedStat
-  })
-  return aggregateByDayPruned
+  for (const stat in aggregateByDate) {
+    delete stat.county
+    delete stat.test_date
+  }
+  return aggregateByDate
 }
 
 /**

--- a/stats.js
+++ b/stats.js
@@ -134,7 +134,7 @@ exports.getAggregateByDate = byDate => {
 
   // Remove unwanted values after using test_date in moving average calc sorter
   const aggregateByDayPruned = aggregateByDate.map(stat => {
-    const prunedStat = {...stat}
+    const prunedStat = { ...stat }
     delete prunedStat.county
     delete prunedStat.test_date
     return prunedStat

--- a/stats.js
+++ b/stats.js
@@ -125,15 +125,21 @@ exports.getAggregateByDate = byDate => {
   const aggregateByDate = {}
   for (const date in byDate) {
     aggregateByDate[date] = exports.sumTestingData(byDate[date], true)
-    delete aggregateByDate[date].county
-    delete aggregateByDate[date].test_date
   }
   // Calculate the moving averages for the aggregate dates.
   const aggregateByDayAsArray = Object.keys(aggregateByDate).map(
     date => aggregateByDate[date]
   )
   exports.getMovingAverage(aggregateByDayAsArray)
-  return aggregateByDate
+
+  // Remove unwanted values after using test_date in moving average calc sorter
+  const aggregateByDayPruned = aggregateByDate.map(stat => {
+    const prunedStat = {...stat}
+    delete prunedStat.county
+    delete prunedStat.test_date
+    return prunedStat
+  })
+  return aggregateByDayPruned
 }
 
 /**


### PR DESCRIPTION
The server-side moving average calculations at county level are fine now, and at state level they seem to be fine except that they are calculated in the wrong direction: they're the average of a day and the 6 days after it instead of the 6 days before it; meaning that the last value of the rolling averages line in the charts always incorrectly equals the last daily figure.

Rolling averages calculated **in-app (left/first)** vs calculated on **server (right/last)**:

<img width=340 src="https://user-images.githubusercontent.com/29628323/110497587-7fd26a00-80ee-11eb-918f-b39a2e44b4ab.PNG" /> <img width=340 src="https://user-images.githubusercontent.com/29628323/110497269-341fc080-80ee-11eb-8399-d9217f924dd1.PNG" /> 

Looking into it, it looks like the logic is correct but the function to sort the values prior to calculating the averages is failing in the statewide case because it sorts based on `stat.test_date` but for statewide stats, the `test_date` value is deleted before that function is called. (For county level stats, the values are deleted in a copy of the original data and the original data is passed to the moving averages calculation). 

This moves that deletion to after the moving averages are calculated.
