### PR TITLE
Add test_date for statewide moving average

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -125,6 +125,7 @@ exports.getAggregateByDate = byDate => {
   const aggregateByDate = {}
   for (const date in byDate) {
     aggregateByDate[date] = exports.sumTestingData(byDate[date], true)
+    aggregateByDate[date].test_date = date
   }
   // Calculate the moving averages for the aggregate dates.
   const aggregateByDayAsArray = Object.keys(aggregateByDate).map(
@@ -133,9 +134,9 @@ exports.getAggregateByDate = byDate => {
   exports.getMovingAverage(aggregateByDayAsArray)
 
   // Remove unwanted values after using test_date in moving average calc sorter
-  for (const stat in aggregateByDate) {
-    delete stat.county
-    delete stat.test_date
+  for (const date in aggregateByDate) {
+    delete aggregateByDate[date].county
+    delete aggregateByDate[date].test_date
   }
   return aggregateByDate
 }


### PR DESCRIPTION
It looks like https://github.com/covid-alert-ny/covid-green-regional-lambdas/pull/26 didn't work because the `test_date` prop that was being prematurely deleted was actually already deleted in another prior function. 

This explicitly adds it before using it in the moving average calculation then deleting it.